### PR TITLE
[Fixes #171 #172 #185] Add Project Description Field and Change in Table UI

### DIFF
--- a/BackEndApp/v1/views.py
+++ b/BackEndApp/v1/views.py
@@ -185,6 +185,7 @@ def edit_project(request):
 
         project_id = request.data.get("project_id")
         project_name = request.data.get("project_name")
+        project_description = request.data.get("project_description")
         data_dir = request.data.get("data_dir")
         output_file_name = request.data.get("output_file_name")
 
@@ -198,6 +199,9 @@ def edit_project(request):
 
         metadata["project_name"] = (
             project_name if project_name is not None else metadata["project_name"]
+        )
+        metadata["project_description"] = (
+            project_description if project_description is not None else metadata["project_description"]
         )
         metadata["data_dir"] = (
             data_dir if data_dir is not None else metadata["data_dir"]
@@ -248,6 +252,7 @@ def create_project(request):
 
         project_id = generate_uid()
         project_name = request.data.get("project_name")
+        project_description = request.data.get("project_description")
         lang = request.data.get("language")
         lib = request.data.get("library")
         task = request.data.get("task")
@@ -262,6 +267,7 @@ def create_project(request):
         metadata = {
             "project_id": project_id,
             "project_name": project_name,
+            "project_description": project_description,
             "lib": lib,
             "lang": lang,
             "task": task,

--- a/FrontEndApp/v1-react/src/Components/MainApp/Homeindex.js
+++ b/FrontEndApp/v1-react/src/Components/MainApp/Homeindex.js
@@ -107,6 +107,7 @@ function Home() {
   const classes = useStyles();
   const [values, setValues] = React.useState({
     project_name: "",
+    project_description: "",
     data_dir: "",
     language: "Python",
     task: "Classification",
@@ -191,6 +192,7 @@ function Home() {
     setValues({
       ...values,
       project_name: "",
+      project_description: "",
       data_dir: "",
       language: "python",
       task: "Classification",
@@ -207,6 +209,7 @@ function Home() {
     setValues({
       ...values,
       project_name: proj.project_name,
+      project_description: proj.project_description,
       data_dir: proj.data_dir,
       language: proj.lang,
       task: proj.task,
@@ -222,6 +225,7 @@ function Home() {
     // vallidation
     if (
       values.project_name !== "" &&
+      values.project_description !== "" &&
       values.path !== "" &&
       values.output_file_name !== ""
     ) {
@@ -230,6 +234,7 @@ function Home() {
           // 'language':values.language,
           // 'library':values.library,
           project_name: values.project_name,
+          project_description: values.project_description,
           project_id: SelectedProject.project_id,
           data_dir: values.data_dir,
           output_file_name: values.output_file_name,
@@ -242,6 +247,7 @@ function Home() {
           language: values.language,
           library: values.library,
           project_name: values.project_name,
+          project_description: values.project_description,
           task: values.task,
           path: values.data_dir,
           output_file_name: values.output_file_name,
@@ -310,6 +316,31 @@ function Home() {
               autoComplete="Project Name"
               autoFocus
               onChange={handleChange("project_name")}
+            />
+          )}
+
+          {IsEdit ? (
+            <TextField
+              variant="outlined"
+              margin="normal"
+              required
+              fullWidth
+              defaultValue={values.project_description}
+              label="Project Description"
+              size="small"
+              autoComplete="Project Description"
+              onChange={handleChange("project_description")}
+            />
+          ) : (
+            <TextField
+              variant="outlined"
+              margin="normal"
+              required
+              fullWidth
+              label="Project Description"
+              size="small"
+              autoComplete="Project Description"
+              onChange={handleChange("project_description")}
             />
           )}
 

--- a/FrontEndApp/v1-react/src/Components/MainApp/Project_table.js
+++ b/FrontEndApp/v1-react/src/Components/MainApp/Project_table.js
@@ -1,22 +1,11 @@
 import React, { useState, useEffect } from "react";
 import { withStyles, makeStyles } from "@material-ui/core/styles";
-import Table from "@material-ui/core/Table";
-import TableBody from "@material-ui/core/TableBody";
-import TableCell from "@material-ui/core/TableCell";
-import TableContainer from "@material-ui/core/TableContainer";
-import TableHead from "@material-ui/core/TableHead";
-import TableRow from "@material-ui/core/TableRow";
-import Paper from "@material-ui/core/Paper";
+import { Typography, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Dialog, DialogActions, DialogTitle, Button, IconButton, Menu, MenuItem } from "@material-ui/core";
 import DeleteIcon from "@material-ui/icons/Delete";
 import EditIcon from "@material-ui/icons/Edit";
-import Dialog from "@material-ui/core/Dialog";
-import DialogActions from "@material-ui/core/DialogActions";
-import DialogTitle from "@material-ui/core/DialogTitle";
-import Button from "@material-ui/core/Button";
-import HomeService from "./HomeService";
-import Typography from "@material-ui/core/Typography";
-import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
+import MoreVertIcon from '@material-ui/icons/MoreVert';
 import AddCircleIcon from "@material-ui/icons/AddCircle";
+import HomeService from "./HomeService";
 
 const StyledTableCell = withStyles((theme) => ({
   head: {
@@ -26,16 +15,7 @@ const StyledTableCell = withStyles((theme) => ({
   body: {
     fontSize: 14,
   },
-  title: {},
 }))(TableCell);
-
-const StyledTableRow = withStyles((theme) => ({
-  root: {
-    "&:nth-of-type(odd)": {
-      backgroundColor: theme.palette.action.hover,
-    },
-  },
-}))(TableRow);
 
 const useStyles = makeStyles({
   table: {
@@ -61,8 +41,9 @@ const useStyles = makeStyles({
 
 export default function Project_table(props) {
   const classes = useStyles();
-  const [open, setOpen] = React.useState(false);
-  const [current_project, setcurrent_project] = React.useState("");
+  const [open, setOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [currentProject, setCurrentProject] = useState(null);
   var username = JSON.parse(localStorage.getItem("username"));
   var token = JSON.parse(localStorage.getItem("token"));
 
@@ -78,8 +59,9 @@ export default function Project_table(props) {
     setOpen(false);
     const data = {
       username: username,
-      project_id: current_project.project_id,
-      project_name: current_project.project_name,
+      project_id: currentProject.project_id,
+      project_name: currentProject.project_name,
+      project_description: currentProject.project_description,
     };
     const res = await HomeService.delete_project(token, data);
     console.log(res);
@@ -87,14 +69,24 @@ export default function Project_table(props) {
     // window.location.reload();
   };
 
+  const handleActionsOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  }
+
+  const handleActionsClose = () => {
+    setAnchorEl(null);
+  }
+
   const handleEdit = (project) => {
     console.log(project.project_id);
+    handleActionsClose();
     props.editproject(project);
   };
-
+  
   const handleDelete = (project) => {
     console.log(project.project_id);
-    setcurrent_project(project);
+    handleActionsClose();
+    setCurrentProject(project);
     setOpen(true);
   };
 
@@ -128,12 +120,7 @@ export default function Project_table(props) {
       ) : (
         <>
           <div>
-            <Typography
-              className={classes.title}
-              variant="h6"
-              id="tableTitle"
-              component="div"
-            >
+            <Typography className={classes.title} variant="h6" id="tableTitle" component="div">
               Projects
             </Typography>
             <Typography className={classes.floatright}>
@@ -147,19 +134,14 @@ export default function Project_table(props) {
             <Table className={classes.table} aria-label="customized table">
               <TableHead>
                 <TableRow>
-                  <StyledTableCell>Name</StyledTableCell>
+                  <StyledTableCell align="center">Name</StyledTableCell>
                   <StyledTableCell align="center">Language</StyledTableCell>
                   <StyledTableCell align="center">Library</StyledTableCell>
-                  <StyledTableCell align="center">
-                    Data Directory
-                  </StyledTableCell>
+                  <StyledTableCell align="center">Data Directory</StyledTableCell>
                   <StyledTableCell align="center">Task</StyledTableCell>
-                  <StyledTableCell align="center">
-                    Output File Name
-                  </StyledTableCell>
-                  <StyledTableCell align="center"></StyledTableCell>
-                  <StyledTableCell align="center"></StyledTableCell>
-                  <StyledTableCell align="center"></StyledTableCell>
+                  <StyledTableCell align="center">Output File Name</StyledTableCell>
+                  <StyledTableCell align="center">Project Description</StyledTableCell>
+                  <StyledTableCell align="center">Actions</StyledTableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -167,47 +149,54 @@ export default function Project_table(props) {
                   <>
                     {Object.keys(project).map((p, index) => (
                       <>
-                        <StyledTableRow key={project[p].project_id}>
-                          <StyledTableCell component="th" scope="row">
+                        <TableRow hover className={classes.hover} key={project[p].project_id}>
+                          <StyledTableCell align="center" component="th" scope="row" onClick={() => props.handlestep(project[p])}>
                             {project[p].project_name}
                           </StyledTableCell>
-                          <StyledTableCell align="center">
+                          <StyledTableCell align="center" onClick={() => props.handlestep(project[p])}>
                             {project[p].lang}
                           </StyledTableCell>
-                          <StyledTableCell align="center">
+                          <StyledTableCell align="center" onClick={() => props.handlestep(project[p])}>
                             {project[p].lib}
                           </StyledTableCell>
-                          <StyledTableCell align="center">
+                          <StyledTableCell align="center" onClick={() => props.handlestep(project[p])}>
                             {project[p].data_dir}
                           </StyledTableCell>
-                          <StyledTableCell align="center">
+                          <StyledTableCell align="center" onClick={() => props.handlestep(project[p])}>
                             {project[p].task}
                           </StyledTableCell>
-                          <StyledTableCell align="center">
+                          <StyledTableCell align="center" onClick={() => props.handlestep(project[p])}>
                             {project[p].output_file_name}
                           </StyledTableCell>
-                          <StyledTableCell
-                            align="center"
-                            className={classes.hover}
-                            onClick={() => handleEdit(project[p])}
-                          >
-                            <EditIcon />
+                          <StyledTableCell align="center" onClick={() => props.handlestep(project[p])}>
+                            {project[p].project_description}
                           </StyledTableCell>
-                          <StyledTableCell
-                            align="center"
-                            className={classes.hover}
-                            onClick={() => handleDelete(project[p])}
-                          >
-                            <DeleteIcon />
+                          <StyledTableCell align="center" onClick={() => setCurrentProject(project[p])}>
+                            <IconButton
+                              aria-controls="customized-menu"
+                              aria-label="options"
+                              aria-haspopup="true"
+                              onClick={handleActionsOpen}
+                            >
+                              <MoreVertIcon />
+                            </IconButton>
+                            <Menu
+                              id="customized-menu"
+                              anchorEl={anchorEl}
+                              elevation={1}
+                              keepMounted
+                              open={Boolean(anchorEl)}
+                              onClose={handleActionsClose}
+                            >
+                              <MenuItem onClick={() => handleEdit(currentProject)}>
+                                <EditIcon /> &nbsp; Edit
+                              </MenuItem>
+                              <MenuItem onClick={() => handleDelete(currentProject)}>
+                                <DeleteIcon /> &nbsp; Delete
+                              </MenuItem>
+                            </Menu>
                           </StyledTableCell>
-                          <StyledTableCell
-                            align="center"
-                            className={classes.hover}
-                            onClick={() => props.handlestep(project[p])}
-                          >
-                            <ArrowForwardIcon />
-                          </StyledTableCell>
-                        </StyledTableRow>
+                        </TableRow>
                       </>
                     ))}
                   </>


### PR DESCRIPTION
## Pull Request

fixes #171 #172 #185

### Description
- The Edit and Delete icons from the table is replaced by an Options icon (providing Edit and Delete options).
- On hover the Table row is highlighted.
- On clicking the Table row it redirects to the respective project page (`/step-2`).
- Project Description field support added in the client-side and server-side (`views.py`).

### Checklist:
- [x] Followed the guidelines mentioned in our [Contributing document](../CONTRIBUTING.md)
- [x] Ensured that there aren't other open [Pull Requests](https://www.github.com/Auto-DL/Generator/pulls) for the same update/change
- [x] This PR is linked to an [Issue](https://www.github.com/Auto-DL/Generator/issues) and the issue number has been mentioned in the title and body of the PR
- [x] The code is clean and docstrings have been added or updated as required
- [x] Code is linted/formatted locally prior to submission (using `prettier` and `black`)

