### PR TITLE
[Fixes #261] Separate the state of password fields of Login and Registration form

### DIFF
--- a/FrontEndApp/v1-react/src/Components/Login/LoginForm.js
+++ b/FrontEndApp/v1-react/src/Components/Login/LoginForm.js
@@ -121,6 +121,12 @@ function LoginForm() {
 
   const handleChangetabs = (event, newValue) => {
     setValue(newValue);
+    values.registerPassword = "";
+    values.confirmpassword = "";
+    values.loginPassword = "";
+    values.showRegisterPassword=false;
+    values.showLoginPassword=false;
+
   };
 
   const login = async () => {

--- a/FrontEndApp/v1-react/src/Components/Login/LoginForm.js
+++ b/FrontEndApp/v1-react/src/Components/Login/LoginForm.js
@@ -80,9 +80,11 @@ function LoginForm() {
     email: "",
     first_name: "",
     last_name: "",
-    password: "",
+    loginPassword: "",
+    registerPassword:"",
     confirmpassword: "",
-    showPassword: false,
+    showLoginPassword: false,
+    showRegisterPassword:false,
   });
 
   const [open, setOpen] = React.useState(false);
@@ -103,8 +105,12 @@ function LoginForm() {
     setValues({ ...values, [prop]: event.target.value });
   };
 
-  const handleClickShowPassword = () => {
-    setValues({ ...values, showPassword: !values.showPassword });
+  const handleClickShowLoginPassword = () => {
+    setValues({ ...values, showLoginPassword: !values.showLoginPassword });
+  };
+
+  const handleClickShowRegisterPassword = () => {
+    setValues({ ...values, showRegisterPassword: !values.showRegisterPassword });
   };
 
   const handleMouseDownPassword = (event) => {
@@ -120,10 +126,10 @@ function LoginForm() {
   const login = async () => {
     const data = {
       username: values.username,
-      password: values.password,
+      password: values.loginPassword,
     };
     // vallidation
-    if (values.username !== "" && values.password !== "") {
+    if (values.username !== "" && values.loginPassword !== "") {
       const res = await LoginService.login(data);
       if (res.status === 200) {
         setalert({ ...values, msg: res.data.message, severity: "success" });
@@ -151,19 +157,20 @@ function LoginForm() {
       first_name: values.first_name,
       last_name: values.last_name,
       email: values.email,
-      password: values.password,
+      password: values.registerPassword,
     };
-    // vallidation
+
+    // validation
     if (
       values.username &&
       values.username.trim() &&
-      values.password &&
+      values.registerPassword &&
       values.first_name &&
       values.first_name.trim() &&
       values.last_name &&
       values.last_name.trim() &&
       values.email &&
-      values.password === values.confirmpassword
+      values.registerPassword === values.confirmpassword
     ) {
       const res = await LoginService.register(data);
       if (res.status === 200) {
@@ -226,23 +233,23 @@ function LoginForm() {
                     onChange={handleChange("username")}
                   />
 
-                  <FormControl fullWidth margin="normal" variant="filled">
-                    <InputLabel htmlFor="outlined-adornment-password">
+                  <FormControl fullWidth margin="normal" variant="outlined">
+                    <InputLabel htmlFor="outlined-adornment-password" style={{backgroundColor: "white",padding:"0px 5px"}}>
                       Password *
                     </InputLabel>
                     <OutlinedInput
-                      type={values.showPassword ? "text" : "password"}
-                      value={values.password}
-                      onChange={handleChange("password")}
+                      type={values.showLoginPassword ? "text" : "password"}
+                      value={values.loginPassword}
+                      onChange={handleChange("loginPassword")}
                       endAdornment={
                         <InputAdornment position="end">
                           <IconButton
                             aria-label="toggle password visibility"
-                            onClick={handleClickShowPassword}
+                            onClick={handleClickShowLoginPassword}
                             onMouseDown={handleMouseDownPassword}
                             edge="end"
                           >
-                            {values.showPassword ? (
+                            {values.showLoginPassword ? (
                               <Visibility />
                             ) : (
                               <VisibilityOff />
@@ -314,23 +321,23 @@ function LoginForm() {
                     onChange={handleChange("email")}
                   />
 
-                  <FormControl fullWidth margin="normal" variant="filled">
-                    <InputLabel htmlFor="outlined-adornment-password">
+                  <FormControl fullWidth margin="normal" variant="outlined" >
+                    <InputLabel variant="outlined" htmlFor="outlined-adornment-password"  style={{backgroundColor: "white",padding:"0px 5px"}}>
                       Password *
                     </InputLabel>
                     <OutlinedInput
-                      type={values.showPassword ? "text" : "password"}
-                      value={values.password}
-                      onChange={handleChange("password")}
+                      type={values.showRegisterPassword ? "text" : "password"}
+                      value={values.registerPassword}
+                      onChange={handleChange("registerPassword")}
                       endAdornment={
                         <InputAdornment position="end">
                           <IconButton
                             aria-label="toggle password visibility"
-                            onClick={handleClickShowPassword}
+                            onClick={handleClickShowRegisterPassword}
                             onMouseDown={handleMouseDownPassword}
                             edge="end"
                           >
-                            {values.showPassword ? (
+                            {values.showRegisterPassword ? (
                               <Visibility />
                             ) : (
                               <VisibilityOff />
@@ -341,23 +348,23 @@ function LoginForm() {
                     />
                   </FormControl>
 
-                  <FormControl fullWidth margin="normal" variant="filled">
-                    <InputLabel htmlFor="outlined-adornment-password">
+                  <FormControl fullWidth margin="normal" variant="outlined">
+                    <InputLabel htmlFor="outlined-adornment-password"  style={{backgroundColor:"white",padding:"0px 5px"}}>
                       Confirm Password *
                     </InputLabel>
                     <OutlinedInput
-                      type={values.showPassword ? "text" : "password"}
+                      type={values.showRegisterPassword ? "text" : "password"}
                       value={values.confirmpassword}
                       onChange={handleChange("confirmpassword")}
                       endAdornment={
                         <InputAdornment position="end">
                           <IconButton
                             aria-label="toggle password visibility"
-                            onClick={handleClickShowPassword}
+                            onClick={handleClickShowRegisterPassword}
                             onMouseDown={handleMouseDownPassword}
                             edge="end"
                           >
-                            {values.showPassword ? (
+                            {values.showRegisterPassword ? (
                               <Visibility />
                             ) : (
                               <VisibilityOff />


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #261 

- The password fields of the login and registration form now have their separate states and their related actions (toggling of visibility) are handled separately. 
- Also fixed a UI bug, now the password labels also transition and move to the top of the border-outline on focus like the other form labels

![Screenshot from 2021-07-25 23-36-52](https://user-images.githubusercontent.com/55556417/126908869-11b2044a-4307-4042-881c-52b95cd30f6e.png)



## What part does this affect?
- [x] FrontEnd.
- [ ] BackEnd.
- [ ] Documentation.
- [ ] Other. (Please specify below)

<!-- Please explain what part of the code this PR affects. -->

## Before submitting
- [x] Was this discussed/approved via a GitHub issue or slack?
- [x] Did you read the [contributor guideline](https://github.com/Auto-DL/Auto-DL/blob/v1-beta/CONTRIBUTING.md)?
- [x] Did you ensure that there aren't any other open [Pull Requests](https://www.github.com/Auto-DL/Generator/pulls) for the same update/change?
- [x] Did you make sure the title is self-explanatory and the description concisely explains the PR?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure the code is clean and docstrings have been added or updated as required?
- [x] Did you make sure the code is linted/formatted locally prior to submission? (using `black` and/or `prettier`)
- [ ] Did you make sure to update the documentation with your changes? (if necessary)

## PR review
Anyone in the community is free to review the PR once the tests have passed.
<!-- In case you have signed-off you're commits, please cut and paste the signed-off by line here at the end -->

Thank you for contributing to [AutoDL](https://github.com/Auto-DL/Auto-DL). We look forward to your continued support.
