### PR TITLE
Option to download project as executable

### DIFF
--- a/BackEndApp/deployments/models.py
+++ b/BackEndApp/deployments/models.py
@@ -1,6 +1,7 @@
 import os
 import git
 import shutil
+import PyInstaller.__main__
 
 from .utils import zip_flask_app
 from .exceptions import (
@@ -86,14 +87,22 @@ class Deployment:
 
                 return response
             else:
-                status, success, message = (
-                    200,
-                    True,
-                    "Executable Downloaded Successfully",
+                app = os.path.join(self.deployment_dir, "app.py")
+                dist_path = os.path.abspath('dist')
+                PyInstaller.__main__.run([
+                    app,
+                    "--onefile",
+                    "--clean",
+                ])
+                response = HttpResponse(
+                    open(os.path.join(dist_path, 'app.exe'), "rb"),
+                    headers={
+                        "Content-Type": "application/vnd.microsoft.portable-executable",
+                        "Content-Disposition": "attachment; filename=app.exe",
+                    },
                 )
-                return JsonResponse(
-                    {"success": success, "message": message}, status=status
-                )
+
+                return response
 
         except Exception as e:
             raise AppDownloadFailed(self.deployment_dir) from e

--- a/BackEndApp/requirements.txt
+++ b/BackEndApp/requirements.txt
@@ -11,6 +11,7 @@ gunicorn==20.1.0
 python-dotenv==0.15.0
 pymongo==3.11.2
 PyGithub==1.54.0.1
+PyInstaller==4.5.1
 GitPython==3.1.18
 # requirements-dev
 pre-commit==2.13.0

--- a/FrontEndApp/v1-react/src/Components/Deployment/DeployProjectModal.js
+++ b/FrontEndApp/v1-react/src/Components/Deployment/DeployProjectModal.js
@@ -189,7 +189,7 @@ const DeployProjectModal = ({ setOpenDeployModal, setDeployOptions, localDeploy,
     const handleCloseDeployModal = () => {
         setDeployStep(0);
         setModelDeployCategories([]);
-        setLocalDeployVariant("zip");
+        setLocalDeployVariant("executable");
         setCurrentPklFile("");
         setPklFileName("");
         setNumberOfChunks(0);
@@ -215,9 +215,14 @@ const DeployProjectModal = ({ setOpenDeployModal, setDeployOptions, localDeploy,
         if (res.status === 200) {
             const { data } = await res;
             const downloadUrl = window.URL.createObjectURL(new Blob([data]));
+            const localDeployVariant = document.querySelector('[name=localDeployVariant]:checked').value;
             const link = document.createElement('a');
+            const fileName = {
+                zip: 'deployment.zip',
+                executable: 'app.exe',
+            };
             link.href = downloadUrl;
-            link.setAttribute('download', 'deployment.zip');
+            link.setAttribute('download', fileName[localDeployVariant]);
             document.body.appendChild(link);
             link.click();
             link.remove();

--- a/FrontEndApp/v1-react/src/Components/Deployment/modals/LocalDeployment.js
+++ b/FrontEndApp/v1-react/src/Components/Deployment/modals/LocalDeployment.js
@@ -16,7 +16,7 @@ export const LocalDeployStepThree = ({ handleCloseDeployModal, setDeployStep, cl
                 </Typography>
                 <FormControl component="fieldset">
                     <RadioGroup aria-label="gender" name="localDeployVariant" value={localDeployVariant} onChange={(e) => setLocalDeployVariant(e.target.value)}>
-                        <FormControlLabel value="executable" disabled control={<Radio />} label="Download an Executable" />
+                        <FormControlLabel value="executable" control={<Radio />} label="Download an Executable" />
                         <FormControlLabel value="zip" control={<Radio />} label="Download a Zipped Folder" />
                     </RadioGroup>
                 </FormControl>


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Enabled option to download project as executable in step 3 of local deployment.
- Got rid of default `deployment.zip` name for executable

Dependencies required for change: PyInstaller v4.5.1

## What part does this affect?
- [x] FrontEnd.
- [x] BackEnd.
- [ ] Documentation.
- [ ] Other. (Please specify below)

Main files affected were `download_app()` in `models.py` and changed default file name in `DeployProjectModal.js`.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue or slack?
- [x] Did you read the [contributor guideline](https://github.com/Auto-DL/Auto-DL/blob/v1-beta/CONTRIBUTING.md)?
- [x] Did you ensure that there aren't any other open [Pull Requests](https://www.github.com/Auto-DL/Generator/pulls) for the same update/change?
- [x] Did you make sure the title is self-explanatory and the description concisely explains the PR?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure the code is clean and docstrings have been added or updated as required?
- [x] Did you make sure the code is linted/formatted locally prior to submission? (using `black` and/or `prettier`)
- [ ] Did you make sure to update the documentation with your changes? (if necessary)

## PR review
Anyone in the community is free to review the PR once the tests have passed.
<!-- In case you have signed-off you're commits, please cut and paste the signed-off by line here at the end -->

Thank you for contributing to [AutoDL](https://github.com/Auto-DL/Auto-DL). We look forward to your continued support.
