### PR TITLE
fix: parameter persistence on layout

### DIFF
--- a/FrontEndApp/v1-react/src/Components/Login/LoginIndex.js
+++ b/FrontEndApp/v1-react/src/Components/Login/LoginIndex.js
@@ -11,7 +11,7 @@ import GitHubResponse from "../MainApp/step-2/GitHubResponse";
 
 function LoginIndex() {
   
-  const step2Ref = useRef();
+  const step2Ref = useRef(null);
 
   return (
     <>

--- a/FrontEndApp/v1-react/src/Components/Login/LoginIndex.js
+++ b/FrontEndApp/v1-react/src/Components/Login/LoginIndex.js
@@ -1,25 +1,28 @@
 import { BrowserRouter, Route, Switch, Redirect } from "react-router-dom";
-import React from "react";
+import React, { useRef } from "react";
 import LoginForm from "./LoginForm";
 import Homeindex from "../MainApp/Homeindex";
 import ProfileIndex from "../ProfilePage/ProfileIndex";
 import Deployment from "../Deployment/DeploymentIndex";
 import Layout from "../MainApp/Layout";
-import step2 from "../MainApp/Step2";
+import Step2 from "../MainApp/Step2";
 import AuthorizeGitHub from "../MainApp/step-2/AuthorizeGithub.js";
 import GitHubResponse from "../MainApp/step-2/GitHubResponse";
 
 function LoginIndex() {
+  
+  const step2Ref = useRef();
+
   return (
     <>
       <BrowserRouter>
-        <Layout />
+        <Layout step2Ref={step2Ref} />
         <Switch>
           <Route path="/login" exact component={LoginForm} />
           <Route path="/home" component={Homeindex} />
           <Route path="/profile" component={ProfileIndex} />
           <Route path="/deploy" component={Deployment} />
-          <Route path="/step-2" component={step2} />
+          <Route path="/step-2" render={(props) => <Step2  ref={step2Ref} {...props} />}/>
           <Route path="/github/authorize" component={AuthorizeGitHub} />
           <Route path="/github/status/" component={GitHubResponse} />
           <Redirect to="/login" />

--- a/FrontEndApp/v1-react/src/Components/MainApp/Layout.js
+++ b/FrontEndApp/v1-react/src/Components/MainApp/Layout.js
@@ -97,7 +97,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-function Layout() {
+function Layout( { step2Ref }) {
   const classes = useStyles();
   const theme = useTheme();
   const history = useHistory();
@@ -109,8 +109,10 @@ function Layout() {
   const openAvatarDropdown = Boolean(anchorEl);
 
   const handleClick = (event) => {
+    if(history.location.pathname == '/step-2') step2Ref.current.saveStep2();
     setAnchorEl(event.currentTarget);
   };
+
   const handleClose = () => {
     setAnchorEl(null);
   };
@@ -124,19 +126,29 @@ function Layout() {
     setOpen(false);
   };
 
+
   const home = () => {
     console.log("home");
+    if(history.location.pathname == '/step-2') step2Ref.current.saveStep2();
     history.push("/home");
     handleDrawerClose();
   };
 
   const deploy = () => {
     console.log("deployments");
+    if(history.location.pathname == '/step-2') step2Ref.current.saveStep2();
     history.push("/deploy");
     handleDrawerClose();
   };
 
+  const profile = () => {
+    console.log("profile");
+    if(history.location.pathname == '/step-2') step2Ref.current.saveStep2();
+    history.push("/profile");
+  }
+
   const logout = () => {
+    if(history.location.pathname == '/step-2') step2Ref.current.saveStep2();
     localStorage.clear();
     history.push("/login");
     window.location.reload();
@@ -207,7 +219,7 @@ function Layout() {
                   "aria-labelledby": "basic-button"
                 }}
               >
-                <MenuItem onClick={() => history.push('/profile')}>Profile</MenuItem>
+                <MenuItem onClick={profile}>Profile</MenuItem>
                 <MenuItem onClick={logout}>Logout</MenuItem>
                 <MenuItem onClick={handleClose}>
                   Delete Account

--- a/FrontEndApp/v1-react/src/Components/MainApp/Step2.js
+++ b/FrontEndApp/v1-react/src/Components/MainApp/Step2.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect,forwardRef, useImperativeHandle } from "react";
 import {
   Button,
   AppBar,
@@ -65,7 +65,8 @@ function a11yProps(index) {
   };
 }
 
-function Step2() {
+const Step2 = forwardRef((props, ref) => {
+
   const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const [alertopen, setAlertopen] = React.useState(false);
@@ -222,6 +223,23 @@ function Step2() {
     } else {
     }
   }
+
+  useImperativeHandle(ref, () => ({
+
+    saveStep2(){
+      if(value == 1){
+        saveData();
+      }
+      else if(value == 0){
+        savepre();
+      }
+      else {
+        savehyper();
+      }
+    }
+
+  }));
+
 
   const handleChangetabs = (event, newValue) => {
     if (newValue !== 1 && value === 1) {
@@ -2937,6 +2955,6 @@ function Step2() {
       </Snackbar>
     </div>
   );
-}
+})
 
 export default Step2;


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #217

The parameters for step-2 are persisting now wherever the user navigate using either inside tabs or outer layout links. 
For tabs inside step2, data was already being saved onchanging those tabs , now I am saving it on outer tab changes as well.

Find the Demo :

https://user-images.githubusercontent.com/56475750/153682251-93e6c698-8f07-4469-bece-dc4adf61e897.mp4



## What part does this affect?
- [x] FrontEnd.
- [ ] BackEnd.
- [ ] Documentation.
- [ ] Other. (Please specify below)

<!-- Please explain what part of the code this PR affects. -->

## Before submitting
- [x] Was this discussed/approved via a GitHub issue or slack?
- [x] Did you read the [contributor guideline](https://github.com/Auto-DL/Auto-DL/blob/v1-beta/CONTRIBUTING.md)?
- [x] Did you ensure that there aren't any other open [Pull Requests](https://www.github.com/Auto-DL/Generator/pulls) for the same update/change?
- [x] Did you make sure the title is self-explanatory and the description concisely explains the PR?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure the code is clean and docstrings have been added or updated as required?
- [x] Did you make sure the code is linted/formatted locally prior to submission? (using `black` and/or `prettier`)
- [x] Did you make sure to update the documentation with your changes? (if necessary)

## PR review
Anyone in the community is free to review the PR once the tests have passed.
<!-- In case you have signed-off you're commits, please cut and paste the signed-off by line here at the end -->

Thank you for contributing to [AutoDL](https://github.com/Auto-DL/Auto-DL). We look forward to your continued support.
